### PR TITLE
Remove codes related to javah

### DIFF
--- a/src/JaLAJni/Makefile
+++ b/src/JaLAJni/Makefile
@@ -17,13 +17,13 @@ DYLIB_BLAS = $(JAVA_HOME)/lib/libjni_cblas.dylib
 
 # For package JaLAJni
 JC = javac
-JH = javah
+# JH = javah
 JFLAGS = -d
 JAVA_SRC_LAPACK = $(JNI_SRC)/java/jniLAPACKE.java
 JAVA_SRC_BLAS = $(JNI_SRC)/java/jniCBLAS.java
 PACKAGE = $(JAVA_HOME)/class/JaLAJni
-HEADER_LAPACK = $(JNI_SRC)/c/include/jniLAPACKE.h
-HEADER_BLAS = $(JNI_SRC)/c/include/jniCBLAS.h
+# HEADER_LAPACK = $(JNI_SRC)/c/include/jniLAPACKE.h
+# HEADER_BLAS = $(JNI_SRC)/c/include/jniCBLAS.h
 
 # header file jniLAPACKE.h
 
@@ -34,13 +34,13 @@ $(PACKAGE): $(JAVA_SRC_LAPACK) $(JAVA_SRC_BLAS)
 	@mkdir -p $(@D)
 	$(JC) $(JFLAGS) $(JAVA_HOME)/class $(JAVA_SRC_LAPACK) $(JAVA_SRC_BLAS)
 
-$(HEADER_LAPACK): 
-	@mkdir -p $(@D)
-	$(JH) -o $(HEADER_LAPACK) -classpath $(JAVA_HOME)/class JaLAJni.jniLAPACKE 
+# $(HEADER_LAPACK): 
+# 	@mkdir -p $(@D)
+# 	$(JH) -o $(HEADER_LAPACK) -classpath $(JAVA_HOME)/class JaLAJni.jniLAPACKE 
 
-$(HEADER_BLAS):
-	@mkdir -p $(@D)
-	$(JH) -o $(HEADER_BLAS) -classpath $(JAVA_HOME)/class JaLAJni.jniCBLAS
+# $(HEADER_BLAS):
+# 	@mkdir -p $(@D)
+# 	$(JH) -o $(HEADER_BLAS) -classpath $(JAVA_HOME)/class JaLAJni.jniCBLAS
 
 $(DYLIB_LAPACK): $(C_SRC_LAPACK)
 	@mkdir -p $(@D)

--- a/src/JaLAJni/c/jniCBLAS.c
+++ b/src/JaLAJni/c/jniCBLAS.c
@@ -1,6 +1,6 @@
 #include <assert.h>
 #include <jni.h>
-#include "jniCBLAS.h"
+// #include "jniCBLAS.h"
 #include "cblas.h"
 
 

--- a/src/JaLAJniLite/Makefile
+++ b/src/JaLAJniLite/Makefile
@@ -20,12 +20,12 @@ DYLIB_BLAS = $(JAVA_HOME)/lib/libblas_lite.dylib
 
 # For package JaLAJniLite
 JC = javac
-JH = javah
+# JH = javah
 JFLAGS = -d
 JAVA_SRC = $(JNI_LAPACK_SRC)/java/jniLAPACK.java $(JNI_BLAS_SRC)/java/jniCBLAS.java
 PACKAGE = $(JAVA_HOME)/class/JaLAJniLite
-HEADER_LAPACK = $(JNI_LAPACK_SRC)/c/include/jniLAPACK.h
-HEADER_BLAS = $(JNI_BLAS_SRC)/c/include/jniCBLAS.h
+# HEADER_LAPACK = $(JNI_LAPACK_SRC)/c/include/jniLAPACK.h
+# HEADER_BLAS = $(JNI_BLAS_SRC)/c/include/jniCBLAS.h
 
 
 all: $(PACKAGE) $(HEADER_LAPACK) $(HEADER_BLAS) $(DYLIB_LAPACK) $(DYLIB_BLAS)
@@ -35,13 +35,13 @@ $(PACKAGE): $(JAVA_SRC)
 	$(JC) $(JFLAGS) $(JAVA_HOME)/class $(JAVA_SRC)
 
 
-$(HEADER_LAPACK): 
-	@mkdir -p $(@D)
-	$(JH) -o $(HEADER_LAPACK) -classpath $(JAVA_HOME)/class JaLAJniLite.jni_lapack.jniLAPACK 
+# $(HEADER_LAPACK): 
+# 	@mkdir -p $(@D)
+# 	$(JH) -o $(HEADER_LAPACK) -classpath $(JAVA_HOME)/class JaLAJniLite.jni_lapack.jniLAPACK 
 
-$(HEADER_BLAS):
-	@mkdir -p $(@D)
-	$(JH) -o $(HEADER_BLAS) -classpath $(JAVA_HOME)/class JaLAJniLite.jni_blas.jniCBLAS
+# $(HEADER_BLAS):
+# 	@mkdir -p $(@D)
+# 	$(JH) -o $(HEADER_BLAS) -classpath $(JAVA_HOME)/class JaLAJniLite.jni_blas.jniCBLAS
 
 $(DYLIB_LAPACK): $(C_SRC_LAPACK)
 	@mkdir -p $(@D)

--- a/src/JaLAJniLite/jni_blas/c/jniCBLAS.c
+++ b/src/JaLAJniLite/jni_blas/c/jniCBLAS.c
@@ -9,7 +9,7 @@
 
 #include <jni.h>
 #include <assert.h>
-#include <jniCBLAS.h>
+//  #include <jniCBLAS.h>
 
 /* Calling fortran blas from libblas */
 

--- a/src/JaLAJniLite/jni_lapack/c/jniLAPACK.c
+++ b/src/JaLAJniLite/jni_lapack/c/jniLAPACK.c
@@ -1,6 +1,6 @@
 #include <jni.h>
 #include <assert.h>
-#include <jniLAPACK.h>
+// #include <jniLAPACK.h>
 #include <stdlib.h>
 
 /* two functions that deal with matrix layout */


### PR DESCRIPTION
I have removed the unnecessary codes related to javah in Makefile, jniCBLAS.c, and jniLAPACK.c files in JaLAJni and JaLAJniLite so that packages can be compiled without javah.